### PR TITLE
feat(providers): add OpenCode (z.ai coding plan) provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **[Homepage](https://devchain.twitechlab.com/)** · **[Quick Start Guide (PDF)](https://devchain.twitechlab.com/docs/devchain-quick-start-guide.pdf)** · **[What's New in v0.10.0](https://devchain.twitechlab.com/releases/0.10.0/)**
 
-Devchain runs your AI coding agents as a coordinated team — each with their own terminal session, task queue, and chat. Assign epics, track progress on a visual board, and let agents collaborate through a structured workflow. Supports Claude Code, Codex, and Gemini CLI out of the box.
+Devchain runs your AI coding agents as a coordinated team — each with their own terminal session, task queue, and chat. Assign epics, track progress on a visual board, and let agents collaborate through a structured workflow. Supports Claude Code, Codex, Gemini CLI, and OpenCode (z.ai) out of the box.
 
 ---
 
@@ -17,7 +17,7 @@ Devchain runs your AI coding agents as a coordinated team — each with their ow
 Spin up isolated agent environments on dedicated git branches. Each worktree gets its own agent team, terminals, and chat — run multiple features in parallel and merge when ready. Worktrees run as Docker containers or local processes with full branch isolation.
 
 ### Container Isolation
-Worktree containers are provisioned automatically from the official Devchain image on [GHCR](https://github.com/orgs/TwiTech-LAB/packages/container/package/devchain). Each container has Claude Code, Codex, and Gemini CLI pre-installed, runs as a non-root user, and shares your git identity for correct commit attribution.
+Worktree containers are provisioned automatically from the official Devchain image on [GHCR](https://github.com/orgs/TwiTech-LAB/packages/container/package/devchain). Each container has Claude Code, Codex, Gemini CLI, and OpenCode pre-installed, runs as a non-root user, and shares your git identity for correct commit attribution.
 
 ### Skills
 Browse and sync AI agent skills from community sources (Anthropic, OpenAI, Vercel, and more). Enable or disable skills per project and expose them to agents via MCP tools.
@@ -32,7 +32,7 @@ Real terminal streaming via tmux and WebSocket. Each agent gets its own session 
 Live pre-commit diff viewer with agent integration, inline comments, `@mentions`, comment threading, and VS Code-style file navigation.
 
 ### Multi-Provider
-Works with Claude Code, OpenAI Codex, Google Gemini CLI, and GLM models. Switch providers per agent or switch the whole team preset with a single click.
+Works with Claude Code, OpenAI Codex, Google Gemini CLI, OpenCode (z.ai), and GLM models. Switch providers per agent or switch the whole team preset with a single click.
 
 ### MCP Integration
 Full Model Context Protocol support. Agents get access to epics, chat, skills, reviews, and more through MCP tools — auto-configured before each session.
@@ -53,6 +53,7 @@ All data stored in a local SQLite database. No cloud account required, no data l
   - [`claude`](https://claude.ai/claude-code) CLI
   - [`codex`](https://github.com/openai/codex) CLI
   - [`gemini`](https://github.com/google-gemini/gemini-cli) CLI
+  - [`opencode`](https://opencode.ai) CLI (z.ai coding plan)
 
 ---
 

--- a/apps/local-app/src/modules/providers/adapters/index.ts
+++ b/apps/local-app/src/modules/providers/adapters/index.ts
@@ -9,4 +9,5 @@ export * from './provider-adapter.factory';
 export * from './claude.adapter';
 export * from './codex.adapter';
 export * from './gemini.adapter';
+export * from './opencode.adapter';
 export * from './provider-adapters.module';

--- a/apps/local-app/src/modules/providers/adapters/opencode.adapter.ts
+++ b/apps/local-app/src/modules/providers/adapters/opencode.adapter.ts
@@ -1,0 +1,57 @@
+import { Injectable } from '@nestjs/common';
+import { ProviderAdapter, AddMcpServerOptions, McpServerEntry } from './provider-adapter.interface';
+
+/**
+ * OpenCode provider adapter (z.ai coding plan)
+ *
+ * Implements MCP command building and output parsing for the OpenCode CLI.
+ * Uses Claude-compatible MCP command structure.
+ */
+@Injectable()
+export class OpencodeAdapter implements ProviderAdapter {
+  readonly providerName = 'opencode';
+
+  addMcpServer(options: AddMcpServerOptions): string[] {
+    const alias = options.alias ?? this.providerName;
+    const args = ['mcp', 'add', '--transport', 'http', alias, options.endpoint];
+    if (options.extraArgs?.length) {
+      args.push(...options.extraArgs);
+    }
+    return args;
+  }
+
+  listMcpServers(): string[] {
+    return ['mcp', 'list'];
+  }
+
+  removeMcpServer(alias: string): string[] {
+    return ['mcp', 'remove', alias];
+  }
+
+  binaryCheck(alias: string): string[] {
+    return ['mcp', 'check', alias];
+  }
+
+  parseListOutput(stdout: string, _stderr?: string): McpServerEntry[] {
+    const entries: McpServerEntry[] = [];
+    const lines = stdout.split('\n').filter((line) => line.trim().length > 0);
+
+    for (const line of lines) {
+      if (line.toLowerCase().startsWith('checking')) {
+        continue;
+      }
+
+      const match = line.match(/^(\S+):\s+(\S+)\s+\(([^)]+)\)/);
+      if (match) {
+        const [, alias, endpoint, transport] = match;
+        entries.push({
+          alias,
+          endpoint,
+          transport: transport.toUpperCase(),
+        });
+      }
+    }
+
+    return entries;
+  }
+}

--- a/apps/local-app/src/modules/providers/adapters/provider-adapter.factory.spec.ts
+++ b/apps/local-app/src/modules/providers/adapters/provider-adapter.factory.spec.ts
@@ -2,6 +2,7 @@ import { ProviderAdapterFactory } from './provider-adapter.factory';
 import { ClaudeAdapter } from './claude.adapter';
 import { CodexAdapter } from './codex.adapter';
 import { GeminiAdapter } from './gemini.adapter';
+import { OpencodeAdapter } from './opencode.adapter';
 import { UnsupportedProviderError } from '../../../common/errors/error-types';
 
 describe('ProviderAdapterFactory', () => {
@@ -9,12 +10,14 @@ describe('ProviderAdapterFactory', () => {
   let claudeAdapter: ClaudeAdapter;
   let codexAdapter: CodexAdapter;
   let geminiAdapter: GeminiAdapter;
+  let opencodeAdapter: OpencodeAdapter;
 
   beforeEach(() => {
     claudeAdapter = new ClaudeAdapter();
     codexAdapter = new CodexAdapter();
     geminiAdapter = new GeminiAdapter();
-    factory = new ProviderAdapterFactory(claudeAdapter, codexAdapter, geminiAdapter);
+    opencodeAdapter = new OpencodeAdapter();
+    factory = new ProviderAdapterFactory(claudeAdapter, codexAdapter, geminiAdapter, opencodeAdapter);
   });
 
   describe('getAdapter', () => {
@@ -36,10 +39,17 @@ describe('ProviderAdapterFactory', () => {
       expect(adapter.providerName).toBe('gemini');
     });
 
+    it('returns OpencodeAdapter for opencode provider', () => {
+      const adapter = factory.getAdapter('opencode');
+      expect(adapter).toBeInstanceOf(OpencodeAdapter);
+      expect(adapter.providerName).toBe('opencode');
+    });
+
     it('returns the exact injected adapter instances (DI)', () => {
       expect(factory.getAdapter('claude')).toBe(claudeAdapter);
       expect(factory.getAdapter('codex')).toBe(codexAdapter);
       expect(factory.getAdapter('gemini')).toBe(geminiAdapter);
+      expect(factory.getAdapter('opencode')).toBe(opencodeAdapter);
     });
 
     it('normalizes provider name to lowercase (case-insensitive lookup)', () => {
@@ -47,12 +57,14 @@ describe('ProviderAdapterFactory', () => {
       expect(factory.getAdapter('CLAUDE')).toBe(claudeAdapter);
       expect(factory.getAdapter('Codex')).toBe(codexAdapter);
       expect(factory.getAdapter('GEMINI')).toBe(geminiAdapter);
+      expect(factory.getAdapter('OpenCode')).toBe(opencodeAdapter);
+      expect(factory.getAdapter('OPENCODE')).toBe(opencodeAdapter);
     });
 
     it('throws UnsupportedProviderError for unsupported provider', () => {
       expect(() => factory.getAdapter('unknown')).toThrow(UnsupportedProviderError);
       expect(() => factory.getAdapter('unknown')).toThrow(
-        'Unsupported provider: unknown. Supported providers: claude, codex, gemini',
+        'Unsupported provider: unknown. Supported providers: claude, codex, gemini, opencode',
       );
     });
 
@@ -68,7 +80,7 @@ describe('ProviderAdapterFactory', () => {
         expect(unsupportedError.code).toBe('unsupported_provider');
         expect(unsupportedError.details).toEqual({
           providerName: 'unknown',
-          supportedProviders: ['claude', 'codex', 'gemini'],
+          supportedProviders: ['claude', 'codex', 'gemini', 'opencode'],
         });
       }
     });
@@ -91,6 +103,10 @@ describe('ProviderAdapterFactory', () => {
       expect(factory.isSupported('gemini')).toBe(true);
     });
 
+    it('returns true for opencode', () => {
+      expect(factory.isSupported('opencode')).toBe(true);
+    });
+
     it('returns false for unsupported provider', () => {
       expect(factory.isSupported('unknown')).toBe(false);
     });
@@ -104,14 +120,16 @@ describe('ProviderAdapterFactory', () => {
       expect(factory.isSupported('CLAUDE')).toBe(true);
       expect(factory.isSupported('Codex')).toBe(true);
       expect(factory.isSupported('GEMINI')).toBe(true);
+      expect(factory.isSupported('OpenCode')).toBe(true);
+      expect(factory.isSupported('OPENCODE')).toBe(true);
     });
   });
 
   describe('getSupportedProviders', () => {
     it('returns array of supported provider names', () => {
       const supported = factory.getSupportedProviders();
-      expect(supported).toEqual(expect.arrayContaining(['claude', 'codex', 'gemini']));
-      expect(supported).toHaveLength(3);
+      expect(supported).toEqual(expect.arrayContaining(['claude', 'codex', 'gemini', 'opencode']));
+      expect(supported).toHaveLength(4);
     });
   });
 });

--- a/apps/local-app/src/modules/providers/adapters/provider-adapter.factory.ts
+++ b/apps/local-app/src/modules/providers/adapters/provider-adapter.factory.ts
@@ -3,12 +3,13 @@ import { ProviderAdapter } from './provider-adapter.interface';
 import { ClaudeAdapter } from './claude.adapter';
 import { CodexAdapter } from './codex.adapter';
 import { GeminiAdapter } from './gemini.adapter';
+import { OpencodeAdapter } from './opencode.adapter';
 import { UnsupportedProviderError } from '../../../common/errors/error-types';
 
 /**
  * Factory for resolving ProviderAdapter instances by provider name
  *
- * Supports known providers only (claude, codex, gemini).
+ * Supports known providers only (claude, codex, gemini, opencode).
  * Throws an error for unsupported provider names.
  */
 @Injectable()
@@ -19,11 +20,13 @@ export class ProviderAdapterFactory {
     claudeAdapter: ClaudeAdapter,
     codexAdapter: CodexAdapter,
     geminiAdapter: GeminiAdapter,
+    opencodeAdapter: OpencodeAdapter,
   ) {
     this.adapters = new Map<string, ProviderAdapter>([
       ['claude', claudeAdapter],
       ['codex', codexAdapter],
       ['gemini', geminiAdapter],
+      ['opencode', opencodeAdapter],
     ]);
   }
 

--- a/apps/local-app/src/modules/providers/adapters/provider-adapters.module.ts
+++ b/apps/local-app/src/modules/providers/adapters/provider-adapters.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ClaudeAdapter } from './claude.adapter';
 import { CodexAdapter } from './codex.adapter';
 import { GeminiAdapter } from './gemini.adapter';
+import { OpencodeAdapter } from './opencode.adapter';
 import { ProviderAdapterFactory } from './provider-adapter.factory';
 
 /**
@@ -12,7 +13,7 @@ import { ProviderAdapterFactory } from './provider-adapter.factory';
  * without creating a dependency cycle.
  */
 @Module({
-  providers: [ClaudeAdapter, CodexAdapter, GeminiAdapter, ProviderAdapterFactory],
+  providers: [ClaudeAdapter, CodexAdapter, GeminiAdapter, OpencodeAdapter, ProviderAdapterFactory],
   exports: [ProviderAdapterFactory],
 })
 export class ProviderAdaptersModule {}

--- a/apps/local-app/src/ui/lib/providers.spec.ts
+++ b/apps/local-app/src/ui/lib/providers.spec.ts
@@ -45,6 +45,19 @@ describe('providers', () => {
       expect(googleSvg).toBe(geminiSvg);
     });
 
+    it('returns SVG for opencode', () => {
+      const svg = getProviderIconSvg('opencode');
+      expect(svg).not.toBeNull();
+      expect(svg).toContain('<svg');
+      expect(svg).toContain('fill="white"');
+    });
+
+    it('returns OpenCode SVG for zai', () => {
+      const zaiSvg = getProviderIconSvg('zai');
+      const opencodeSvg = getProviderIconSvg('opencode');
+      expect(zaiSvg).toBe(opencodeSvg);
+    });
+
     it('returns null for unknown provider', () => {
       expect(getProviderIconSvg('unknown-provider')).toBeNull();
     });
@@ -66,6 +79,7 @@ describe('providers', () => {
       expect(getProviderIconSvg('gpt-4')).not.toBeNull();
       expect(getProviderIconSvg('gemini-pro')).not.toBeNull();
       expect(getProviderIconSvg('google-gemini')).not.toBeNull();
+      expect(getProviderIconSvg('z.ai')).not.toBeNull();
     });
   });
 
@@ -108,6 +122,8 @@ describe('providers', () => {
       expect(hasProviderIcon('codex')).toBe(true);
       expect(hasProviderIcon('gemini')).toBe(true);
       expect(hasProviderIcon('google')).toBe(true);
+      expect(hasProviderIcon('opencode')).toBe(true);
+      expect(hasProviderIcon('zai')).toBe(true);
     });
 
     it('returns false for unknown providers', () => {
@@ -140,6 +156,14 @@ describe('providers', () => {
 
     it('returns proper alt text for google (normalized to gemini)', () => {
       expect(getProviderIconAltText('google-ai')).toBe('Google Gemini icon');
+    });
+
+    it('returns proper alt text for opencode', () => {
+      expect(getProviderIconAltText('opencode')).toBe('OpenCode (z.ai) icon');
+    });
+
+    it('returns proper alt text for zai (normalized to opencode)', () => {
+      expect(getProviderIconAltText('zai')).toBe('OpenCode (z.ai) icon');
     });
 
     it('returns fallback for unknown', () => {

--- a/apps/local-app/src/ui/lib/providers.ts
+++ b/apps/local-app/src/ui/lib/providers.ts
@@ -22,6 +22,14 @@ const GEMINI_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" 
   <path d="M12 0C12 6.627 6.627 12 0 12c6.627 0 12 5.373 12 12 0-6.627 5.373-12 12-12-6.627 0-12-5.373-12-12z"/>
 </svg>`;
 
+// OpenCode (z.ai coding plan) icon
+// Source: https://opencode.ai/favicon.svg
+const OPENCODE_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#131010"/>
+  <path d="M320 224V352H192V224H320Z" fill="#5A5858"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M384 416H128V96H384V416ZM320 160H192V352H320V160Z" fill="white"/>
+</svg>`;
+
 // Map provider names to their SVG icons
 const PROVIDER_ICONS: Record<string, string> = {
   claude: CLAUDE_SVG,
@@ -31,6 +39,8 @@ const PROVIDER_ICONS: Record<string, string> = {
   gpt: OPENAI_SVG,
   gemini: GEMINI_SVG,
   google: GEMINI_SVG,
+  opencode: OPENCODE_SVG,
+  zai: OPENCODE_SVG,
 };
 
 // Cache for data URIs
@@ -51,6 +61,9 @@ function normalizeProviderName(name: string | null | undefined): string | null {
   }
   if (normalized.includes('gemini') || normalized.includes('google')) {
     return 'gemini';
+  }
+  if (normalized.includes('opencode') || normalized.includes('zai') || normalized.includes('z.ai')) {
+    return 'opencode';
   }
   return normalized;
 }
@@ -115,6 +128,7 @@ export function getProviderIconAltText(name: string | null | undefined): string 
     gpt: 'OpenAI GPT',
     gemini: 'Google Gemini',
     google: 'Google',
+    opencode: 'OpenCode (z.ai)',
   };
 
   return `${displayNames[normalized] ?? normalized} icon`;

--- a/apps/local-app/src/ui/pages/ProvidersPage.tsx
+++ b/apps/local-app/src/ui/pages/ProvidersPage.tsx
@@ -25,12 +25,13 @@ import { cn } from '@/ui/lib/utils';
 import { fetchPreflightChecks } from '@/ui/lib/preflight';
 import { useSelectedProject } from '@/ui/hooks/useProjectSelection';
 
-type ProviderType = 'codex' | 'claude' | 'gemini';
+type ProviderType = 'codex' | 'claude' | 'gemini' | 'opencode';
 
 function getDefaultBinPathForType(t: ProviderType) {
   if (t === 'codex') return 'codex';
   if (t === 'claude') return 'claude';
   if (t === 'gemini') return 'gemini';
+  if (t === 'opencode') return 'opencode';
   return '';
 }
 


### PR DESCRIPTION
## Summary

Add support for OpenCode CLI (z.ai coding plan) as a new AI provider.

### Changes

- **New adapter**: `opencode.adapter.ts` implementing `ProviderAdapter` interface
- **MCP commands**: Claude-compatible (`mcp add/list/remove/check --transport http`)
- **UI icon**: opencode.ai favicon SVG with aliases `opencode`, `zai`, `z.ai`
- **Tests**: All existing tests pass + new tests for opencode support

### Files Changed

| File | Change |
|------|--------|
| `apps/local-app/src/modules/providers/adapters/opencode.adapter.ts` | **NEW** - Provider adapter |
| `apps/local-app/src/modules/providers/adapters/index.ts` | Export adapter |
| `apps/local-app/src/modules/providers/adapters/provider-adapters.module.ts` | Register adapter |
| `apps/local-app/src/modules/providers/adapters/provider-adapter.factory.ts` | Add to factory |
| `apps/local-app/src/modules/providers/adapters/provider-adapter.factory.spec.ts` | Add tests |
| `apps/local-app/src/ui/lib/providers.ts` | Add icon + normalization |
| `apps/local-app/src/ui/lib/providers.spec.ts` | Add icon tests |
| `apps/local-app/src/ui/pages/ProvidersPage.tsx` | Add to ProviderType |
| `README.md` | Document new provider |

### Test Results

```
Test Suites: 7 passed, 7 total
Tests: 126 passed, 126 total
```