### PR TITLE
fix: preserve an unsent user draft when delivering a message to a session

### DIFF
--- a/apps/local-app/src/common/test/app-bootstrap.helper.ts
+++ b/apps/local-app/src/common/test/app-bootstrap.helper.ts
@@ -183,6 +183,7 @@ function createProviderAdapterFactoryMock(): Record<string, jest.Mock> {
     isSupported: jest.fn().mockReturnValue(true),
     getSupportedProviders: jest.fn().mockReturnValue(['test']),
     getPostPasteDelayMsForAgent: jest.fn().mockResolvedValue(undefined),
+    getPromptDraftKeysForAgent: jest.fn().mockResolvedValue(undefined),
   };
 }
 

--- a/apps/local-app/src/modules/project-communication/project-delivery-failure-redaction.integration.spec.ts
+++ b/apps/local-app/src/modules/project-communication/project-delivery-failure-redaction.integration.spec.ts
@@ -166,6 +166,7 @@ describe('project delivery failure redaction workflow', () => {
     const messageLog = new MessageLogService();
     const providerAdapterFactory = {
       getPostPasteDelayMsForAgent: jest.fn().mockResolvedValue(undefined),
+      getPromptDraftKeysForAgent: jest.fn().mockResolvedValue(undefined),
     };
     const notifier = new DeliveryFailureNotifierService(terminalIO as never, sessions as never);
     pool = new SessionsMessagePoolService(

--- a/apps/local-app/src/modules/providers/adapters/claude.adapter.ts
+++ b/apps/local-app/src/modules/providers/adapters/claude.adapter.ts
@@ -7,6 +7,7 @@ import type {
   McpServerEntry,
   LaunchInitialPromptBehavior,
   TerminalOutputBehavior,
+  RuntimePromptBehavior,
   BuildLaunchArgsInput,
 } from './provider-adapter.interface';
 import type {
@@ -63,6 +64,14 @@ export class ClaudeAdapter
   readonly launchInitialPromptBehavior: LaunchInitialPromptBehavior = {
     preKeys: ['Enter'],
     preDelayMs: 2000,
+  };
+
+  // Claude's prompt is readline-style: C-u kills the line into a ring that C-y
+  // yanks back ("Ctrl+Y to paste deleted text"). C-e first because C-u alone
+  // kills only to the line start, which would leave the text after the cursor
+  // behind for the injected message to be appended to.
+  readonly runtimePromptBehavior: RuntimePromptBehavior = {
+    promptDraftKeys: { stash: ['C-e', 'C-u'], restore: ['C-y'] },
   };
 
   // Claude's fullscreen renderer previously needed raw LF handling while

--- a/apps/local-app/src/modules/providers/adapters/codex.adapter.ts
+++ b/apps/local-app/src/modules/providers/adapters/codex.adapter.ts
@@ -4,6 +4,7 @@ import type {
   AddMcpServerOptions,
   McpServerEntry,
   LaunchInitialPromptBehavior,
+  RuntimePromptBehavior,
   BuildLaunchArgsInput,
 } from './provider-adapter.interface';
 import type {
@@ -44,6 +45,12 @@ export class CodexAdapter
   readonly launchInitialPromptBehavior: LaunchInitialPromptBehavior = {
     preKeys: ['Enter'],
     preDelayMs: 2000,
+  };
+
+  // Codex's composer implements the same readline kill/yank as Claude's prompt:
+  // C-e C-u clears it retaining the text, C-y restores it verbatim.
+  readonly runtimePromptBehavior: RuntimePromptBehavior = {
+    promptDraftKeys: { stash: ['C-e', 'C-u'], restore: ['C-y'] },
   };
 
   /**

--- a/apps/local-app/src/modules/providers/adapters/provider-adapter.factory.ts
+++ b/apps/local-app/src/modules/providers/adapters/provider-adapter.factory.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { ProviderAdapter } from './provider-adapter.interface';
+import { ProviderAdapter, type RuntimePromptBehavior } from './provider-adapter.interface';
+import type { PromptDraftKeys } from '../../terminal/services/terminal-io/types';
 import { ClaudeAdapter } from './claude.adapter';
 import { CodexAdapter } from './codex.adapter';
 import { OpencodeAdapter } from './opencode.adapter';
@@ -71,6 +72,16 @@ export class ProviderAdapterFactory {
   }
 
   async getPostPasteDelayMsForAgent(agentId: string): Promise<number | undefined> {
+    return (await this.getRuntimePromptBehaviorForAgent(agentId))?.postPasteDelayMs;
+  }
+
+  async getPromptDraftKeysForAgent(agentId: string): Promise<PromptDraftKeys | undefined> {
+    return (await this.getRuntimePromptBehaviorForAgent(agentId))?.promptDraftKeys;
+  }
+
+  private async getRuntimePromptBehaviorForAgent(
+    agentId: string,
+  ): Promise<RuntimePromptBehavior | undefined> {
     try {
       const agent = await this.storage.getAgent(agentId);
       if (!agent.providerConfigId) return undefined;
@@ -85,7 +96,7 @@ export class ProviderAdapterFactory {
       if (!providerName) return undefined;
 
       const adapter = this.adapters.get(providerName.toLowerCase());
-      return adapter?.runtimePromptBehavior?.postPasteDelayMs;
+      return adapter?.runtimePromptBehavior;
     } catch {
       return undefined;
     }

--- a/apps/local-app/src/modules/providers/adapters/provider-adapter.interface.ts
+++ b/apps/local-app/src/modules/providers/adapters/provider-adapter.interface.ts
@@ -1,3 +1,7 @@
+// Type-only import: prompt-draft keys are consumed by terminal delivery, so the
+// shape is defined once there rather than duplicated here.
+import type { PromptDraftKeys } from '../../terminal/services/terminal-io/types';
+
 export interface McpServerEntry {
   alias: string;
   endpoint: string;
@@ -11,6 +15,24 @@ export interface LaunchInitialPromptBehavior {
 
 export interface RuntimePromptBehavior {
   postPasteDelayMs?: number;
+  /**
+   * Keys that stash an in-progress user draft out of the prompt before an
+   * injected message is submitted, and restore it afterwards. Without these, a
+   * message delivered while the user is mid-sentence is submitted together with
+   * their unsent text, and the rest of what they were typing becomes a separate
+   * message.
+   *
+   * Declare ONLY for providers whose prompt implements readline-style
+   * kill/yank, verified against the real TUI: `stash` must clear the prompt from
+   * ANY cursor position (`C-u` alone kills only to line start, so it needs a
+   * preceding `C-e`), and `restore` must put the text back verbatim.
+   *
+   * Delivery issues stash, paste, submit and restore as a single tmux command
+   * list so the user cannot type into the middle of it, which leaves no room for
+   * `postPasteDelayMs` between the paste and the submit. Only declare these for a
+   * provider that ingests a bracketed paste before reading the following Enter.
+   */
+  promptDraftKeys?: PromptDraftKeys;
 }
 
 export interface TerminalOutputBehavior {

--- a/apps/local-app/src/modules/sessions/services/sessions-message-pool.idle-lane.integration.spec.ts
+++ b/apps/local-app/src/modules/sessions/services/sessions-message-pool.idle-lane.integration.spec.ts
@@ -118,7 +118,10 @@ describe('SessionsMessagePoolService idle lifecycle integration', () => {
         },
         {
           provide: ProviderAdapterFactory,
-          useValue: { getPostPasteDelayMsForAgent: jest.fn(async () => undefined) },
+          useValue: {
+            getPostPasteDelayMsForAgent: jest.fn(async () => undefined),
+            getPromptDraftKeysForAgent: jest.fn(async () => undefined),
+          },
         },
         {
           provide: DeliveryFailureNotifierService,

--- a/apps/local-app/src/modules/sessions/services/sessions-message-pool.service.characterization.spec.ts
+++ b/apps/local-app/src/modules/sessions/services/sessions-message-pool.service.characterization.spec.ts
@@ -53,6 +53,7 @@ describe('SessionsMessagePoolService characterization', () => {
     };
     const providerAdapterFactory = {
       getPostPasteDelayMsForAgent: jest.fn().mockResolvedValue(undefined),
+      getPromptDraftKeysForAgent: jest.fn().mockResolvedValue(undefined),
     };
     const messageLog = new MessageLogService();
     const failureNotifier = { notifySendersOfFailure: jest.fn().mockResolvedValue(undefined) };

--- a/apps/local-app/src/modules/sessions/services/sessions-message-pool.service.spec.ts
+++ b/apps/local-app/src/modules/sessions/services/sessions-message-pool.service.spec.ts
@@ -40,7 +40,7 @@ describe('SessionsMessagePoolService', () => {
   let mockStorage: jest.Mocked<Pick<StorageService, 'getAgent'>>;
   let mockActivityStream: jest.Mocked<MessageActivityStreamService>;
   let mockProviderAdapterFactory: jest.Mocked<
-    Pick<ProviderAdapterFactory, 'getPostPasteDelayMsForAgent'>
+    Pick<ProviderAdapterFactory, 'getPostPasteDelayMsForAgent' | 'getPromptDraftKeysForAgent'>
   >;
 
   const createMockAgent = (overrides: { id?: string; name?: string; projectId?: string } = {}) => ({
@@ -125,6 +125,7 @@ describe('SessionsMessagePoolService', () => {
 
     mockProviderAdapterFactory = {
       getPostPasteDelayMsForAgent: jest.fn().mockResolvedValue(undefined),
+      getPromptDraftKeysForAgent: jest.fn().mockResolvedValue(undefined),
     };
 
     const mockMessageLog = new MessageLogService();

--- a/apps/local-app/src/modules/sessions/services/sessions-message-pool.service.ts
+++ b/apps/local-app/src/modules/sessions/services/sessions-message-pool.service.ts
@@ -987,10 +987,12 @@ export class SessionsMessagePoolService implements OnModuleDestroy {
     try {
       const postPasteDelayMs =
         await this.providerAdapterFactory.getPostPasteDelayMsForAgent(agentId);
+      const draftKeys = await this.providerAdapterFactory.getPromptDraftKeysForAgent(agentId);
       const result = await this.terminalIO.deliver({ name: tmuxSessionId }, baseText, {
         agentId,
         submitKeys,
         postPasteDelayMs,
+        draftKeys,
       });
 
       const deliveredAt = Date.now();
@@ -1091,6 +1093,7 @@ export class SessionsMessagePoolService implements OnModuleDestroy {
     await this.coordinator.withAgentLock(agentId, async () => {
       const postPasteDelayMs =
         await this.providerAdapterFactory.getPostPasteDelayMsForAgent(agentId);
+      const draftKeys = await this.providerAdapterFactory.getPromptDraftKeysForAgent(agentId);
       if (opts?.skipConfirmation) {
         const delivery = await this.terminalIO.deliverImmediate(
           { name: session.tmuxSessionId! },
@@ -1101,6 +1104,7 @@ export class SessionsMessagePoolService implements OnModuleDestroy {
             confirm: false,
             preKeys: opts?.preKeys,
             preDelayMs: opts?.preDelayMs,
+            draftKeys,
           },
         );
         result = { nonce: delivery.nonce, skipped: true, retryCount: 0 };
@@ -1111,6 +1115,7 @@ export class SessionsMessagePoolService implements OnModuleDestroy {
           postPasteDelayMs,
           preKeys: opts?.preKeys,
           preDelayMs: opts?.preDelayMs,
+          draftKeys,
         });
         result = {
           nonce: delivery.nonce,

--- a/apps/local-app/src/modules/sessions/services/sessions.service.spec.ts
+++ b/apps/local-app/src/modules/sessions/services/sessions.service.spec.ts
@@ -57,7 +57,11 @@ describe('SessionsService', () => {
   let sqlitePrepare: jest.Mock;
   let sqliteExec: jest.Mock;
   let insertRunMock: jest.Mock;
-  let providerAdapterFactory: { getAdapter: jest.Mock; getPostPasteDelayMsForAgent: jest.Mock };
+  let providerAdapterFactory: {
+    getAdapter: jest.Mock;
+    getPostPasteDelayMsForAgent: jest.Mock;
+    getPromptDraftKeysForAgent: jest.Mock;
+  };
   let terminalSessionRegistry: {
     create: jest.Mock;
     bind: jest.Mock;
@@ -128,6 +132,7 @@ describe('SessionsService', () => {
     providerAdapterFactory = {
       getAdapter: jest.fn().mockReturnValue({ providerName: 'claude' }),
       getPostPasteDelayMsForAgent: jest.fn().mockResolvedValue(undefined),
+      getPromptDraftKeysForAgent: jest.fn().mockResolvedValue(undefined),
     };
 
     terminalSessionRegistry = {

--- a/apps/local-app/src/modules/sessions/services/sessions.service.ts
+++ b/apps/local-app/src/modules/sessions/services/sessions.service.ts
@@ -728,10 +728,13 @@ export class SessionsService {
       return { confirmed: result.confirmed, method: result.method };
     }
 
+    const draftKeys = await this.providerAdapterFactory.getPromptDraftKeysForAgent(agentId);
+
     const result = await this.terminalIO.deliver({ name: session.tmuxSessionId }, text, {
       agentId,
       submitKeys: ['Enter'],
       postPasteDelayMs,
+      draftKeys,
     });
 
     return { confirmed: result.confirmed, method: result.method };

--- a/apps/local-app/src/modules/terminal/services/terminal-io/delivery.spec.ts
+++ b/apps/local-app/src/modules/terminal/services/terminal-io/delivery.spec.ts
@@ -346,6 +346,317 @@ describe('TerminalIOService delivery', () => {
     });
   });
 
+  // A message delivered while the user is mid-sentence used to be submitted
+  // together with their unsent text, and the rest of what they were typing
+  // arrived as a second, contextless message. The prompt is a shared surface, so
+  // delivery has to move the draft aside and put it back.
+  //
+  // The draft below is the reason this matters rather than merely confuses:
+  // whole, it holds the merge back until a condition is met; cut after "merge
+  // PR #10" it orders the merge outright, and agents act on such instructions
+  // on their own.
+  describe('delivery while the user has an unsent draft', () => {
+    const DRAFT = 'merge PR #10 only after the migration test passes';
+    const draftKeys = { stash: ['C-e', 'C-u'], restore: ['C-y'] } as const;
+
+    async function typeDraft(fake: FakeProcessExecutor, svc: TerminalIOService, text: string) {
+      fake.enqueueResponse({ type: 'success' });
+      await svc.sendControl(target, ['-l', '--', text]);
+    }
+
+    /** Responses for the draft path up to (not including) the submit. */
+    function enqueueStashSequence(fake: FakeProcessExecutor, stashChangedPane = true) {
+      fake.enqueueResponse({ type: 'success' }); // if-shell: leave any tmux mode
+      fake.enqueueResponse({ type: 'success', stdout: 'prompt with draft' }); // capture before
+      fake.enqueueResponse({ type: 'success' }); // stash keys
+      fake.enqueueResponse({
+        type: 'success',
+        stdout: stashChangedPane ? 'prompt now empty' : 'prompt with draft',
+      }); // capture after
+    }
+
+    function callsWith(fake: FakeProcessExecutor, from: number, needle: string) {
+      return fake.calls.slice(from).filter((call) => call.argv.includes(needle));
+    }
+
+    it('stashes the draft, submits the message alone, then restores the draft', async () => {
+      const { fake, svc } = makeService();
+      await typeDraft(fake, svc, DRAFT);
+      const from = fake.calls.length;
+      enqueueStashSequence(fake);
+      fake.enqueueResponse({ type: 'success' }); // load-buffer
+      fake.enqueueResponse({ type: 'success' }); // paste-buffer
+      fake.enqueueResponse({ type: 'success' }); // delete-buffer
+      fake.enqueueResponse({ type: 'success' }); // submit + restore
+
+      const result = await svc.deliver(target, 'agent message', {
+        agentId: 'a1',
+        confirm: false,
+        postPasteDelayMs: 0,
+        draftKeys,
+      });
+
+      expect(result.confirmed).toBe(true);
+      const after = fake.calls.slice(from).map((c) => c.argv.join(' '));
+      const idx = (needle: string) => after.findIndex((a) => a.includes(needle));
+      // mode is left first, then the stash, then the paste, then the submit
+      expect(idx('pane_in_mode')).toBeLessThan(idx('C-u'));
+      expect(idx('C-u')).toBeLessThan(idx('paste-buffer'));
+      expect(idx('paste-buffer')).toBeLessThan(idx('Enter'));
+      expect(idx('Enter')).toBeLessThan(idx('C-y') + 1);
+    });
+
+    // A pane in copy-mode consumes send-keys for its own bindings, so the stash
+    // would silently do nothing while the paste still landed — at the cursor,
+    // inside the draft. Leaving any mode first is what prevents that.
+    it('takes the pane out of any tmux mode before sending the stash', async () => {
+      const { fake, svc } = makeService();
+      await typeDraft(fake, svc, DRAFT);
+      const from = fake.calls.length;
+      enqueueStashSequence(fake);
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+
+      await svc.deliver(target, 'agent message', {
+        agentId: 'a1',
+        confirm: false,
+        postPasteDelayMs: 0,
+        draftKeys,
+      });
+
+      const cancel = callsWith(fake, from, 'if-shell')[0];
+      expect(cancel).toBeDefined();
+      expect(cancel.argv.join(' ')).toContain('#{pane_in_mode}');
+      expect(cancel.argv.join(' ')).toContain('cancel');
+    });
+
+    // If the stash left the pane unchanged it never reached the provider. Pasting
+    // then would drop the message into the middle of the draft, so preservation is
+    // abandoned and the message is delivered the ordinary way instead of lost.
+    it('falls back to ordinary delivery when the stash cannot be verified', async () => {
+      const { fake, svc } = makeService();
+      await typeDraft(fake, svc, DRAFT);
+      const from = fake.calls.length;
+      enqueueStashSequence(fake, false); // pane unchanged after the stash
+      // ordinary path: load-buffer, paste-buffer, delete-buffer, submit
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+
+      const result = await svc.deliver(target, 'agent message', {
+        agentId: 'a1',
+        confirm: false,
+        postPasteDelayMs: 0,
+        draftKeys,
+      });
+
+      expect(result.confirmed).toBe(true);
+      // the message still went out, and no restore was attempted
+      expect(callsWith(fake, from, 'paste-buffer').length).toBeGreaterThan(0);
+      expect(callsWith(fake, from, 'C-y')).toHaveLength(0);
+    });
+
+    // The stash keys clear a single line, so a multiline draft keeps its first
+    // line and a paste would land after the remnant. Seeing the start of the
+    // draft still in the pane is what catches that.
+    it('falls back, and hands back what it killed, when the draft is still visible', async () => {
+      const { fake, svc } = makeService();
+      await typeDraft(fake, svc, DRAFT);
+      const from = fake.calls.length;
+      fake.enqueueResponse({ type: 'success' }); // if-shell
+      fake.enqueueResponse({ type: 'success', stdout: DRAFT }); // capture before
+      fake.enqueueResponse({ type: 'success' }); // stash keys
+      // the pane changed, but the start of the draft is still sitting there
+      fake.enqueueResponse({ type: 'success', stdout: `${DRAFT} (partly cleared)` });
+      fake.enqueueResponse({ type: 'success' }); // undo the partial stash
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+
+      const result = await svc.deliver(target, 'agent message', {
+        agentId: 'a1',
+        confirm: false,
+        postPasteDelayMs: 0,
+        draftKeys,
+      });
+
+      expect(result.confirmed).toBe(true);
+      // whatever the stash took is yanked back before the ordinary delivery, or the
+      // message would be submitted with that part of the draft missing
+      expect(callsWith(fake, from, 'C-y')).toHaveLength(1);
+      expect(callsWith(fake, from, 'paste-buffer').length).toBeGreaterThan(0);
+    });
+
+    // REGRESSION: the submit once shared a command list with the paste, for
+    // atomicity. A provider that assembles a bracketed paste asynchronously then
+    // swallows the submit arriving in the same breath, and the message is lost
+    // outright — strictly worse than the truncation this path exists to prevent.
+    it('never puts the submit in the same command list as the paste', async () => {
+      const { fake, svc } = makeService();
+      await typeDraft(fake, svc, DRAFT);
+      const from = fake.calls.length;
+      enqueueStashSequence(fake);
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+
+      await svc.deliver(target, 'agent message', {
+        agentId: 'a1',
+        confirm: false,
+        postPasteDelayMs: 0,
+        draftKeys,
+      });
+
+      for (const call of fake.calls.slice(from)) {
+        expect(call.argv.includes('paste-buffer') && call.argv.includes('Enter')).toBe(false);
+      }
+    });
+
+    it('leaves delivery untouched when the user has typed nothing', async () => {
+      const { fake, svc } = makeService();
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+
+      await svc.deliver(target, 'agent message', {
+        agentId: 'a1',
+        confirm: false,
+        postPasteDelayMs: 0,
+        draftKeys,
+      });
+
+      const keys = fake.calls.flatMap((call) => call.argv);
+      expect(keys).not.toContain('C-u');
+      expect(keys).not.toContain('C-y');
+      expect(keys.join(' ')).not.toContain('pane_in_mode');
+    });
+
+    // Restoring a draft that is not there would yank whatever the provider's kill
+    // ring still holds into the prompt, so a committed draft must not count.
+    it('does not stash or restore after the user submits their draft', async () => {
+      const { fake, svc } = makeService();
+      await typeDraft(fake, svc, DRAFT);
+      fake.enqueueResponse({ type: 'success' });
+      await svc.sendControl(target, ['Enter']);
+      const from = fake.calls.length;
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+
+      await svc.deliver(target, 'agent message', {
+        agentId: 'a1',
+        confirm: false,
+        postPasteDelayMs: 0,
+        draftKeys,
+      });
+
+      expect(callsWith(fake, from, 'C-y')).toHaveLength(0);
+    });
+
+    it('skips draft handling for providers that declare no draft keys', async () => {
+      const { fake, svc } = makeService();
+      await typeDraft(fake, svc, DRAFT);
+      const from = fake.calls.length;
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+
+      await svc.deliver(target, 'agent message', {
+        agentId: 'a1',
+        confirm: false,
+        postPasteDelayMs: 0,
+      });
+
+      expect(callsWith(fake, from, 'C-u')).toHaveLength(0);
+    });
+
+    // Terminals batch fast typing, so a submit can arrive at the tail of a chunk.
+    it('treats a submit at the end of a typed chunk as emptying the prompt', async () => {
+      const { fake, svc } = makeService();
+      await typeDraft(fake, svc, `${DRAFT}\r`);
+      const from = fake.calls.length;
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+
+      await svc.deliver(target, 'agent message', {
+        agentId: 'a1',
+        confirm: false,
+        postPasteDelayMs: 0,
+        draftKeys,
+      });
+
+      expect(callsWith(fake, from, 'C-u')).toHaveLength(0);
+    });
+
+    // The stash keys clear one line, so a draft spanning several cannot be moved
+    // aside at all. Delivery must not touch it: a partial stash would leave part of
+    // the draft in the kill ring and submit the message with the rest.
+    it('does not try to stash a multiline draft', async () => {
+      const { fake, svc } = makeService();
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      await svc.deliverImmediate(target, 'first line\nsecond line', {
+        bracketed: true,
+        submitKeys: [],
+      });
+      const from = fake.calls.length;
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+
+      const result = await svc.deliver(target, 'agent message', {
+        agentId: 'a1',
+        confirm: false,
+        postPasteDelayMs: 0,
+        draftKeys,
+      });
+
+      // delivered the ordinary way, with the prompt left exactly as the user left it
+      expect(result.confirmed).toBe(true);
+      expect(callsWith(fake, from, 'paste-buffer').length).toBeGreaterThan(0);
+      expect(callsWith(fake, from, 'C-u')).toHaveLength(0);
+      expect(callsWith(fake, from, 'C-y')).toHaveLength(0);
+      expect(callsWith(fake, from, 'if-shell')).toHaveLength(0);
+    });
+
+    // A newline-insert binding grows the draft; treating it as a submit would lose
+    // track of the draft and let the next delivery stash a multiline prompt.
+    it('counts an escape-prefixed return as a newline, not a submit', async () => {
+      const { fake, svc } = makeService();
+      await typeDraft(fake, svc, 'first line');
+      fake.enqueueResponse({ type: 'success' });
+      await svc.sendControl(target, ['-l', '--', '\x1b\r']);
+      await typeDraft(fake, svc, 'second line');
+      const from = fake.calls.length;
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+      fake.enqueueResponse({ type: 'success' });
+
+      await svc.deliver(target, 'agent message', {
+        agentId: 'a1',
+        confirm: false,
+        postPasteDelayMs: 0,
+        draftKeys,
+      });
+
+      // the draft is known to be multiline, so it is left alone
+      expect(callsWith(fake, from, 'C-u')).toHaveLength(0);
+    });
+  });
+
   describe('sendControl', () => {
     it('sends control keys via tmux send-keys', async () => {
       const { fake, svc } = makeService();

--- a/apps/local-app/src/modules/terminal/services/terminal-io/delivery.ts
+++ b/apps/local-app/src/modules/terminal/services/terminal-io/delivery.ts
@@ -1,5 +1,5 @@
 import type { ProcessExecutor } from '../process-executor/process-executor.port';
-import type { SessionTarget, DeliveryOptions, DeliveryResult } from './types';
+import type { SessionTarget, DeliveryOptions, DeliveryResult, PromptDraftKeys } from './types';
 import { captureStrict } from './capture';
 import { generateDeliveryNonce } from '../../../../common/delivery-nonce';
 
@@ -9,6 +9,20 @@ const DEFAULT_MAX_ATTEMPTS = 2;
 const DEFAULT_CONFIRM_TIMEOUT_MS = 2000;
 const CONFIRM_POLL_INTERVAL_MS = 150;
 const CONFIRM_TAIL_LINES = 10;
+/**
+ * Pause after a key send that changes the prompt, before a paste is issued into
+ * it. Covers both the provider applying the keys and the fact that keys and
+ * pastes reach the pane by different routes.
+ */
+const KEY_SETTLE_MS = 150;
+/**
+ * Pause after the submit, before the draft is yanked back. Submitting sends the
+ * provider into a re-render, during which a yank arriving immediately is dropped
+ * and the draft stays in the kill ring instead of the prompt.
+ */
+const SUBMIT_SETTLE_MS = 250;
+/** How long to keep looking for the restored draft before repairing it. */
+const RESTORE_CONFIRM_TIMEOUT_MS = 1500;
 
 function clampDelay(raw: number | undefined, fallback: number): number {
   const v = raw ?? fallback;
@@ -65,6 +79,27 @@ async function confirmPasteDelivery(
     }
 
     await new Promise<void>((r) => setTimeout(r, CONFIRM_POLL_INTERVAL_MS));
+  }
+}
+
+/**
+ * Poll until the pane shows `probe`. A restored draft can take a moment to render,
+ * and a slow render is indistinguishable from a lost yank at any single instant —
+ * which is exactly the mistake that produced both an empty prompt and a doubled
+ * one, depending on which way the race fell.
+ */
+async function waitForPaneText(
+  executor: ProcessExecutor,
+  target: SessionTarget,
+  probe: string,
+  timeoutMs: number,
+): Promise<boolean> {
+  const startedAt = Date.now();
+  for (;;) {
+    const capture = await captureStrict(executor, target, CONFIRM_TAIL_LINES);
+    if (capture.ok && capture.output.includes(probe)) return true;
+    if (Date.now() - startedAt >= timeoutMs) return false;
+    await new Promise((r) => setTimeout(r, CONFIRM_POLL_INTERVAL_MS));
   }
 }
 
@@ -131,6 +166,198 @@ async function sendSubmitKeysWithRetry(
     await new Promise((r) => setTimeout(r, 150));
     await sendKeys(executor, target, keys);
   }
+}
+
+/**
+ * Deliver into a pane that currently holds an unsent user draft.
+ *
+ * The prompt is a shared surface: the user types into the same pane we inject
+ * into. Submitting a message therefore commits whatever the user has typed so
+ * far along with it, and their remaining keystrokes become a second, contextless
+ * message. To avoid that, the draft is stashed out of the prompt, the message is
+ * pasted and submitted alone, and the draft is put back.
+ *
+ * Keys and pastes do not reach the pane by the same route. `send-keys` goes
+ * through tmux's key handling, which a pane in copy-mode consumes for its own
+ * bindings, while `paste-buffer` writes into the application regardless. A pane
+ * enters copy-mode whenever the user scrolls it. So a stash issued into a pane in
+ * copy-mode silently does nothing while the paste still lands — at the text
+ * cursor, in the middle of the draft, which is then submitted around it.
+ *
+ * Each step is therefore issued on its own and checked, and the provider is given
+ * time to apply it before the next:
+ *
+ *   1. cancel any tmux mode — otherwise the keys below go to copy-mode
+ *   2. stash, then check the pane changed and no longer shows the draft's start
+ *   3. paste, then wait for the provider to assemble it
+ *   4. confirm — the message is still unsubmitted, so a paste that never landed
+ *      is caught before anything is committed
+ *   5. submit, wait out the re-render it triggers, then restore; a yank sent into
+ *      that re-render is dropped, leaving the draft in the kill ring
+ *
+ * The restore is polled for rather than checked once, because a slow render and a
+ * lost yank look identical at any single instant. If it really did not arrive, a
+ * stash-then-restore repairs it: that holds whether the draft is absent or merely
+ * rendered late, so the prompt ends up with exactly one copy either way.
+ *
+ * When the stash cannot be verified, whatever it took is handed back and the
+ * caller is told, which falls back to delivering without preservation: the message
+ * still arrives, merged into the draft as it was before this path existed. Every
+ * failure degrades to the old behaviour rather than to a lost, doubled, or
+ * corrupted message.
+ *
+ * A draft spanning several lines never reaches here — the stash keys clear one
+ * line, so it cannot be moved aside at all.
+ */
+async function pasteAndSubmitPreservingDraft(
+  executor: ProcessExecutor,
+  target: SessionTarget,
+  text: string,
+  options: {
+    bracketed: boolean;
+    submitKeys: readonly string[];
+    draftKeys: PromptDraftKeys;
+    draftProbe?: string;
+    postPasteDelayMs: number;
+    nonce?: string;
+    confirmTimeoutMs: number;
+  },
+): Promise<{
+  confirmed: boolean;
+  stashFailed?: boolean;
+  method?: 'nonce' | 'paste_indicator' | 'paste_changed';
+}> {
+  const paneTarget = `=${target.name}:`;
+  const commandList = (commands: ReadonlyArray<readonly string[]>): string[] => {
+    const argv: string[] = ['tmux'];
+    for (const command of commands) {
+      if (argv.length > 1) argv.push(';');
+      argv.push(...command);
+    }
+    return argv;
+  };
+  const runCommandList = async (
+    commands: ReadonlyArray<readonly string[]>,
+    phase: string,
+  ): Promise<void> => {
+    if (commands.length === 0) return;
+    const result = await executor.run({ argv: commandList(commands), mode: 'pipe' });
+    if (!result.success) {
+      throw new Error(
+        `Failed to ${phase} for draft-preserving delivery to "${target.name}": ${result.stderr}`,
+      );
+    }
+  };
+  const sendKeysCommand = (keys: readonly string[]): string[][] =>
+    keys.map((key) => ['send-keys', '-t', paneTarget, key]);
+
+  // A pane in copy-mode eats the stash keys, so leave any mode before sending them.
+  await runCommandList(
+    [
+      [
+        'if-shell',
+        '-F',
+        '-t',
+        paneTarget,
+        '#{pane_in_mode}',
+        `send-keys -X -t '${paneTarget}' cancel`,
+      ],
+    ],
+    'leave any tmux mode',
+  );
+
+  const beforeStash = await captureStrict(executor, target, CONFIRM_TAIL_LINES);
+  const baseline = beforeStash.ok ? beforeStash.output : undefined;
+
+  const prepared = text.replace(/\r?\n/g, '\r');
+  const payload = options.bracketed ? `\x1b[200~${prepared}\x1b[201~` : prepared;
+
+  const safeSession = target.name.replace(/[^a-zA-Z0-9_.-]/g, '');
+  const bufferName = `devchain-${safeSession}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`;
+
+  await runCommandList(sendKeysCommand(options.draftKeys.stash), 'stash the draft');
+  await new Promise((r) => setTimeout(r, KEY_SETTLE_MS));
+
+  // Two ways the stash can fall short, both of which would drop the message into
+  // the middle of the draft if we pasted now: the keys never reached the provider
+  // (an unchanged pane), or they cleared only part of the draft — the stash keys
+  // act on one line, so a multiline draft keeps its other lines. Either way, give
+  // up on preserving and let the caller deliver the ordinary way.
+  const afterStash = await captureStrict(executor, target, CONFIRM_TAIL_LINES);
+  if (afterStash.ok) {
+    const unchanged = baseline !== undefined && afterStash.output === baseline;
+    const draftStillVisible =
+      options.draftProbe !== undefined && afterStash.output.includes(options.draftProbe);
+    if (unchanged || draftStillVisible) {
+      // A partial stash has part of the draft in the kill ring; hand it back before
+      // giving up, or the ordinary delivery would submit the draft without it. When
+      // the pane never changed nothing was killed, and yanking then would pull
+      // whatever the ring held from before into the prompt.
+      if (!unchanged) {
+        await runCommandList(sendKeysCommand(options.draftKeys.restore), 'undo a partial stash');
+      }
+      return { confirmed: false, stashFailed: true };
+    }
+  }
+
+  await loadBuffer(executor, bufferName, payload);
+  try {
+    await runCommandList(
+      [['paste-buffer', '-b', bufferName, '-t', target.name]],
+      'paste the message',
+    );
+  } finally {
+    await deleteBuffer(executor, bufferName);
+  }
+
+  if (options.postPasteDelayMs > 0) {
+    await new Promise((r) => setTimeout(r, options.postPasteDelayMs));
+  }
+
+  let method: 'nonce' | 'paste_indicator' | 'paste_changed' | undefined;
+  if (options.nonce) {
+    const confirmation = await confirmPasteDelivery(
+      executor,
+      target,
+      options.nonce,
+      baseline,
+      options.confirmTimeoutMs,
+    );
+    if (!confirmation.confirmed && !confirmation.captureError) {
+      // Nothing has been submitted: give the draft back and report the failure.
+      await runCommandList(sendKeysCommand(options.draftKeys.restore), 'restore the draft');
+      return { confirmed: false };
+    }
+    method = confirmation.method;
+  }
+
+  await runCommandList(sendKeysCommand(options.submitKeys), 'submit the message');
+
+  // The submit puts the provider into a re-render; a yank sent into that is lost.
+  await new Promise((r) => setTimeout(r, SUBMIT_SETTLE_MS));
+  await runCommandList(sendKeysCommand(options.draftKeys.restore), 'restore the draft');
+
+  // The draft only exists in the provider's kill ring now, so a yank the provider
+  // dropped would leave the prompt empty.
+  if (options.draftProbe !== undefined) {
+    const restored = await waitForPaneText(
+      executor,
+      target,
+      options.draftProbe,
+      RESTORE_CONFIRM_TIMEOUT_MS,
+    );
+    if (!restored) {
+      // Stash-then-restore rather than a second bare yank: if the draft is in fact
+      // there and merely rendered late, the stash takes it back into the kill ring
+      // and the yank returns it, so either way the prompt ends up holding exactly
+      // one copy. A second bare yank would append another.
+      await runCommandList(sendKeysCommand(options.draftKeys.stash), 'restash before repair');
+      await new Promise((r) => setTimeout(r, KEY_SETTLE_MS));
+      await runCommandList(sendKeysCommand(options.draftKeys.restore), 'repair the restore');
+    }
+  }
+
+  return { confirmed: true, method };
 }
 
 async function pasteAndSubmit(
@@ -234,12 +461,29 @@ export interface SendGap {
   clear(): void;
 }
 
+/**
+ * Live pane state, as opposed to caller intent in `DeliveryOptions`. Tracked by
+ * `TerminalIOService`, which sees every write to a pane.
+ */
+export interface DeliveryRuntimeState {
+  /** The pane holds text the user has typed but not yet submitted. */
+  readonly hasPendingDraft?: boolean;
+  /** The start of that draft, used to verify the stash cleared the prompt. */
+  readonly draftProbe?: string;
+  /**
+   * The draft spans more than one line. The stash keys clear a single line, so
+   * such a draft cannot be moved aside and delivery does not try.
+   */
+  readonly multilineDraft?: boolean;
+}
+
 export async function deliver(
   executor: ProcessExecutor,
   gap: SendGap,
   target: SessionTarget,
   text: string,
   options: DeliveryOptions,
+  runtime: DeliveryRuntimeState = {},
 ): Promise<DeliveryResult> {
   const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
   const submitKeys = options.submitKeys ?? ['Enter'];
@@ -247,6 +491,36 @@ export async function deliver(
   const postPasteDelayMs = clampDelay(options.postPasteDelayMs, DEFAULT_POST_PASTE_DELAY_MS);
   const confirmTimeoutMs = options.confirmTimeoutMs ?? DEFAULT_CONFIRM_TIMEOUT_MS;
   const confirm = options.confirm ?? true;
+
+  // `preKeys` belongs to the launch handshake, which runs before any user can
+  // have typed; leave that path exactly as it was rather than reordering it.
+  const draftKeys =
+    runtime.hasPendingDraft && !runtime.multilineDraft && !options.preKeys?.length
+      ? options.draftKeys
+      : undefined;
+  if (draftKeys) {
+    const nonce = generateDeliveryNonce();
+    await gap.ensureGap(options.agentId);
+    const preserved = await pasteAndSubmitPreservingDraft(
+      executor,
+      target,
+      `${text}\n[MsgId:${nonce}]`,
+      {
+        bracketed,
+        submitKeys,
+        draftKeys,
+        draftProbe: runtime.draftProbe,
+        postPasteDelayMs,
+        nonce: confirm ? nonce : undefined,
+        confirmTimeoutMs,
+      },
+    );
+    // A stash that could not be verified leaves the draft untouched, so fall
+    // through to ordinary delivery rather than dropping the message.
+    if (!preserved.stashFailed) {
+      return { confirmed: preserved.confirmed, nonce, retryCount: 0, method: preserved.method };
+    }
+  }
 
   let lastNonce = '';
 
@@ -297,6 +571,7 @@ export async function deliverImmediate(
   target: SessionTarget,
   text: string,
   options: Omit<DeliveryOptions, 'agentId'>,
+  runtime: DeliveryRuntimeState = {},
 ): Promise<DeliveryResult> {
   const submitKeys = options.submitKeys ?? ['Enter'];
   const bracketed = options.bracketed ?? true;
@@ -306,6 +581,27 @@ export async function deliverImmediate(
 
   const nonce = generateDeliveryNonce();
   const textWithNonce = confirm ? `${text}\n[MsgId:${nonce}]` : text;
+
+  // `preKeys` belongs to the launch handshake, which runs before any user can
+  // have typed; leave that path exactly as it was rather than reordering it.
+  const draftKeys =
+    runtime.hasPendingDraft && !options.preKeys?.length ? options.draftKeys : undefined;
+  if (draftKeys) {
+    const preserved = await pasteAndSubmitPreservingDraft(executor, target, textWithNonce, {
+      bracketed,
+      submitKeys,
+      draftKeys,
+      draftProbe: runtime.draftProbe,
+      postPasteDelayMs,
+      nonce: confirm ? nonce : undefined,
+      confirmTimeoutMs,
+    });
+    // A stash that could not be verified leaves the draft untouched, so fall
+    // through to ordinary delivery rather than dropping the message.
+    if (!preserved.stashFailed) {
+      return { confirmed: preserved.confirmed, nonce, retryCount: 0, method: preserved.method };
+    }
+  }
 
   const result = await pasteAndSubmit(executor, target, textWithNonce, {
     bracketed,

--- a/apps/local-app/src/modules/terminal/services/terminal-io/terminal-io.service.ts
+++ b/apps/local-app/src/modules/terminal/services/terminal-io/terminal-io.service.ts
@@ -43,6 +43,8 @@ interface SessionLifecycleState {
 @Injectable()
 export class TerminalIOService implements OnModuleDestroy {
   private readonly gap: SendGap;
+  private readonly draftTracker = new PromptDraftTracker();
+  private readonly paneWrites = new PaneWriteQueue();
   private readonly healthMonitors = new Map<string, HealthMonitorRecord>();
   private readonly lifecycleStates = new Map<string, SessionLifecycleState>();
   private nextMonitorToken = 0;
@@ -63,6 +65,8 @@ export class TerminalIOService implements OnModuleDestroy {
     this.healthMonitors.clear();
     this.lifecycleStates.clear();
     this.gap.clear();
+    this.draftTracker.clearAll();
+    this.paneWrites.clear();
   }
 
   // ── Lifecycle ───────────────────────────────────────────────────────────
@@ -76,6 +80,7 @@ export class TerminalIOService implements OnModuleDestroy {
   }
 
   async destroySession(target: SessionTarget): Promise<void> {
+    this.draftTracker.clear(target.name);
     return lifecycle.destroySession(this.executor, target);
   }
 
@@ -177,6 +182,7 @@ export class TerminalIOService implements OnModuleDestroy {
       argv: ['tmux', 'send-keys', '-t', `=${target.name}:`, 'Enter'],
       mode: 'pipe',
     });
+    this.draftTracker.clear(target.name);
     if (!enterResult.success || enterResult.timedOut) {
       throw new TypeCommandFailedError(
         target.name,
@@ -396,7 +402,30 @@ export class TerminalIOService implements OnModuleDestroy {
     text: string,
     options: DeliveryOptions,
   ): Promise<DeliveryResult> {
-    return deliveryMod.deliver(this.executor, this.gap, target, text, options);
+    return this.paneWrites.run(target.name, async () => {
+      const hasPendingDraft = this.draftTracker.hasPendingDraft(target.name);
+      logger.debug(
+        {
+          session: target.name,
+          agentId: options.agentId,
+          hasPendingDraft,
+          hasDraftKeys: Boolean(options.draftKeys),
+          multilineDraft: this.draftTracker.hasMultilineDraft(target.name),
+          preservesDraft:
+            hasPendingDraft &&
+            Boolean(options.draftKeys) &&
+            !this.draftTracker.hasMultilineDraft(target.name),
+        },
+        'Delivering to pane',
+      );
+      const result = await deliveryMod.deliver(this.executor, this.gap, target, text, options, {
+        hasPendingDraft,
+        draftProbe: this.draftTracker.draftProbe(target.name),
+        multilineDraft: this.draftTracker.hasMultilineDraft(target.name),
+      });
+      this.noteDeliveryCommitted(target, options, hasPendingDraft);
+      return result;
+    });
   }
 
   async deliverImmediate(
@@ -404,11 +433,233 @@ export class TerminalIOService implements OnModuleDestroy {
     text: string,
     options: Omit<DeliveryOptions, 'agentId'>,
   ): Promise<DeliveryResult> {
-    return deliveryMod.deliverImmediate(this.executor, target, text, options);
+    return this.paneWrites.run(target.name, async () => {
+      const hasPendingDraft = this.draftTracker.hasPendingDraft(target.name);
+      const result = await deliveryMod.deliverImmediate(this.executor, target, text, options, {
+        hasPendingDraft,
+        draftProbe: this.draftTracker.draftProbe(target.name),
+        multilineDraft: this.draftTracker.hasMultilineDraft(target.name),
+      });
+      if (!hasPendingDraft || !options.draftKeys) {
+        // No draft was preserved, so the pasted text simply joined whatever is in
+        // the prompt: it is a new draft when nothing submits it, and otherwise the
+        // submit left the prompt empty.
+        if ((options.submitKeys ?? ['Enter']).length === 0) {
+          this.draftTracker.noteDraftContent(target.name, text);
+        } else {
+          this.draftTracker.clear(target.name);
+        }
+      }
+      return result;
+    });
   }
 
   async sendControl(target: SessionTarget, keys: readonly string[]): Promise<void> {
-    return deliveryMod.sendControl(this.executor, target, keys);
+    // Queued behind any injection in flight, so the user's keystrokes cannot land
+    // between a stashed draft and the submit that follows it. They are held, not
+    // dropped, and replay in the order they were typed.
+    return this.paneWrites.run(target.name, async () => {
+      this.draftTracker.noteTypedKeys(target.name, keys);
+      return deliveryMod.sendControl(this.executor, target, keys);
+    });
+  }
+
+  /**
+   * A delivery that ends in a submit key leaves the prompt empty — unless the
+   * draft-preserving path ran, which puts the user's text back.
+   */
+  private noteDeliveryCommitted(
+    target: SessionTarget,
+    options: Omit<DeliveryOptions, 'agentId'>,
+    preservedDraft: boolean,
+  ): void {
+    if (preservedDraft && options.draftKeys) return;
+    if ((options.submitKeys ?? ['Enter']).length === 0) return;
+    this.draftTracker.clear(target.name);
+  }
+}
+
+/**
+ * Serializes writes to a pane, one at a time, in the order they were requested.
+ *
+ * The pane is written to by both the user (keystrokes forwarded from a terminal
+ * view) and by delivery. A draft-preserving delivery has to clear the prompt,
+ * paste, wait for the provider to assemble the paste, and only then submit — so
+ * for the length of that window a keystroke arriving in between would be caught
+ * by the submit. Queuing holds those keystrokes and replays them afterwards
+ * instead, which costs the typist the duration of an injection in latency and is
+ * the reason the injection is kept as short as it can be.
+ */
+class PaneWriteQueue {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  run<T>(pane: string, task: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(pane) ?? Promise.resolve();
+    // `task` runs whether or not the previous write settled: one failed write
+    // must not strand everything queued behind it.
+    const result = previous.then(task, task);
+    const tail: Promise<void> = result.then(
+      () => {},
+      () => {},
+    );
+    this.tails.set(pane, tail);
+    void tail.then(() => {
+      if (this.tails.get(pane) === tail) this.tails.delete(pane);
+    });
+    return result;
+  }
+
+  clear(): void {
+    this.tails.clear();
+  }
+}
+
+/** How much of a draft's start to remember, for verifying that a stash worked. */
+const DRAFT_PROBE_CHARS = 32;
+/**
+ * Shorter than this and a probe risks matching unrelated text in a capture. Kept
+ * low deliberately: a draft of "line 1" has to be long enough to check, and a
+ * false match only costs preservation — delivery then behaves as it always did.
+ */
+const DRAFT_PROBE_MIN_CHARS = 4;
+
+/** tmux key names that leave the provider's prompt empty. */
+const PROMPT_CLEARING_KEYS: ReadonlySet<string> = new Set(['Enter', 'Escape', 'C-c', 'C-u', 'C-g']);
+/** The same actions as raw bytes, for input forwarded literally. */
+const PROMPT_CLEARING_BYTES: ReadonlySet<string> = new Set(['\r', '\n', '\x1b', '\x03', '\x15']);
+
+/**
+ * Tracks, per pane, whether the user has typed something they have not submitted
+ * yet. Delivery needs this: stashing and restoring a draft that is not there
+ * would yank stale text out of the provider's kill ring and into the prompt.
+ *
+ * Every write DevChain makes to a pane passes through TerminalIOService, so this
+ * sees the input it forwards — but not input from a terminal attached to tmux
+ * directly, which reaches the pty without passing here. For those there is no
+ * draft to know about and delivery behaves as it did before. Only a length and a
+ * short prefix are kept, never the whole draft: the provider's own kill ring does
+ * the stashing, so all this needs to answer is whether something is there and
+ * whether it went away.
+ *
+ * It is an approximation: editing keys DevChain does not model (word kills,
+ * history recall) can leave the count non-zero over an empty prompt. The
+ * consequence is bounded — a stash/restore that yanks previously killed text
+ * back into the prompt, visible to the user and never submitted on its own —
+ * whereas missing a real draft merges it into an agent's message.
+ */
+class PromptDraftTracker {
+  private readonly pendingChars = new Map<string, number>();
+  private readonly probes = new Map<string, string>();
+  private readonly multiline = new Set<string>();
+
+  hasPendingDraft(pane: string): boolean {
+    return (this.pendingChars.get(pane) ?? 0) > 0;
+  }
+
+  /**
+   * The start of the draft, for checking afterwards that a stash really cleared
+   * the prompt. The START specifically: the stash keys clear a single line, so a
+   * multiline draft keeps its first line, and looking for the beginning of the
+   * text is what catches that.
+   */
+  /**
+   * Whether the draft is known to span more than one line. The stash keys clear a
+   * single line, so such a draft cannot be moved aside and delivery must not try.
+   */
+  hasMultilineDraft(pane: string): boolean {
+    return this.multiline.has(pane);
+  }
+
+  draftProbe(pane: string): string | undefined {
+    const probe = this.probes.get(pane);
+    return probe && probe.length >= DRAFT_PROBE_MIN_CHARS ? probe : undefined;
+  }
+
+  /** Input the user typed, as the argv tail of a `tmux send-keys` call. */
+  noteTypedKeys(pane: string, keys: readonly string[]): void {
+    if (keys.length === 0) return;
+
+    // `send-keys -l -- <text>`: characters forwarded literally.
+    if (keys[0] === '-l') {
+      this.noteTypedText(pane, keys[keys.length - 1] ?? '');
+      return;
+    }
+    if (keys.some((key) => PROMPT_CLEARING_KEYS.has(key))) {
+      this.clear(pane);
+      return;
+    }
+    if (keys.includes('BSpace')) this.add(pane, -1);
+  }
+
+  /**
+   * Text the user typed. A submit at the end of the chunk empties the prompt;
+   * terminals batch fast typing, so `abc\r` has to count as a submit too.
+   */
+  private noteTypedText(pane: string, text: string): void {
+    if (text.length === 0) return;
+    // An escape-prefixed return is how terminals send the "insert a newline"
+    // binding (alt/shift+enter). It grows the draft rather than submitting it, and
+    // reading it as a submit would lose track of the draft entirely.
+    if (/^\x1b[\r\n]$/.test(text)) {
+      this.add(pane, 1);
+      this.markMultiline(pane);
+      return;
+    }
+    if (text.endsWith('\r') || text.endsWith('\n')) {
+      this.clear(pane);
+      return;
+    }
+    if (text.length === 1 && PROMPT_CLEARING_BYTES.has(text)) {
+      this.clear(pane);
+      return;
+    }
+    this.add(pane, text.length);
+    this.extendProbe(pane, text);
+  }
+
+  /**
+   * Text placed into the prompt without submitting it (a paste). Never a submit,
+   * whatever it contains — so newlines in it are draft content, not a commit.
+   */
+  noteDraftContent(pane: string, text: string): void {
+    this.add(pane, text.length);
+    this.noteNewlinesIn(pane, text);
+    this.extendProbe(pane, text);
+  }
+
+  clear(pane: string): void {
+    this.pendingChars.delete(pane);
+    this.probes.delete(pane);
+    this.multiline.delete(pane);
+  }
+
+  clearAll(): void {
+    this.pendingChars.clear();
+    this.probes.clear();
+    this.multiline.clear();
+  }
+
+  private markMultiline(pane: string): void {
+    this.multiline.add(pane);
+  }
+
+  private noteNewlinesIn(pane: string, text: string): void {
+    if (/[\r\n]/.test(text)) this.markMultiline(pane);
+  }
+
+  private extendProbe(pane: string, text: string): void {
+    const current = this.probes.get(pane) ?? '';
+    if (current.length >= DRAFT_PROBE_CHARS) return;
+    // Only the first line is usable: the capture it gets compared against holds
+    // one prompt line at a time.
+    const firstLine = (current + text).slice(0, DRAFT_PROBE_CHARS).split(/[\r\n]/)[0] ?? '';
+    this.probes.set(pane, firstLine);
+  }
+
+  private add(pane: string, delta: number): void {
+    const next = (this.pendingChars.get(pane) ?? 0) + delta;
+    if (next <= 0) this.pendingChars.delete(pane);
+    else this.pendingChars.set(pane, next);
   }
 }
 

--- a/apps/local-app/src/modules/terminal/services/terminal-io/types.ts
+++ b/apps/local-app/src/modules/terminal/services/terminal-io/types.ts
@@ -42,6 +42,18 @@ export interface WaitForOutputOptions {
   readonly lines?: number;
 }
 
+/**
+ * Keys that move an in-progress user draft out of the prompt before an injected
+ * message is submitted, and put it back afterwards. Providers declare these; see
+ * `RuntimePromptBehavior.promptDraftKeys`.
+ */
+export interface PromptDraftKeys {
+  /** Clears the prompt from any cursor position, retaining the text. */
+  readonly stash: readonly string[];
+  /** Restores the stashed text verbatim. */
+  readonly restore: readonly string[];
+}
+
 export interface DeliveryOptions {
   readonly agentId: string;
   readonly bracketed?: boolean;
@@ -52,6 +64,12 @@ export interface DeliveryOptions {
   readonly confirm?: boolean;
   readonly confirmTimeoutMs?: number;
   readonly maxAttempts?: number;
+  /**
+   * Provider keys used to protect an unsent user draft. Supplied only when the
+   * provider declares support; delivery additionally requires the pane to
+   * actually hold a draft before using them.
+   */
+  readonly draftKeys?: PromptDraftKeys;
 }
 
 export interface DeliveryResult {


### PR DESCRIPTION
## Symptom

A message delivered into a session while the user is typing is submitted together with their unsent text, and the keystrokes they type afterwards arrive as a second, contextless message. The recipient answers the fragment as though it were a new question.

Truncation can invert an instruction rather than merely garble it. A draft of `merge PR #10 only after the migration test passes`, cut after `merge PR #10`, reads as an order to merge — and agents act on such messages on their own.

## Root cause

The prompt is a shared surface: the user types into the same pane delivery injects into. `deliver()` pasted the message and then sent `Enter`, and that `Enter` commits whatever the user had typed along with the pasted text; their later keystrokes then form the next message.

Three further behaviours of the boundary matter, each found while validating the fix against real provider TUIs:

1. **`send-keys` and `paste-buffer` do not reach the pane by the same route.** A pane in tmux copy-mode consumes `send-keys` for its own bindings, while `paste-buffer` writes into the application regardless. Panes enter copy-mode whenever the user scrolls them, so keys sent into one silently vanish while the paste still lands — at the text cursor, mid-draft.
2. **A submit key must not share a command list with the paste.** Providers that assemble a bracketed paste asynchronously swallow a submit arriving in the same breath, losing the message outright.
3. **A yank sent into the re-render that a submit triggers is dropped**, leaving the draft in the kill ring rather than the prompt.

## The fix

When the pane holds an unsent draft and the provider declares keys for it, the draft is stashed out of the prompt, the message is pasted and submitted alone, and the draft is put back. Each step is issued separately and checked, and the provider is given time to apply it:

1. cancel any tmux mode, so the keys below are not eaten by copy-mode
2. stash, then verify the pane changed and no longer shows the start of the draft
3. paste on its own, then wait for the provider to assemble it
4. confirm while the message is still unsubmitted, so a paste that never landed is caught before anything is committed
5. submit, wait out the re-render, then restore — polled for rather than checked once, since a slow render and a lost yank look identical at any instant

If the restore does not arrive, a stash-then-restore repairs it. That holds whether the draft is absent or merely rendered late, so the prompt ends up with exactly one copy either way — a second bare yank would double the text.

**Every failure degrades to today's behaviour rather than to a lost, doubled, or corrupted message.** When the stash cannot be verified, whatever it took is handed back and delivery proceeds without preservation: the message still arrives, merged into the draft exactly as it is on `main` today.

Writes to a pane are serialized, so a keystroke arriving mid-injection is queued and replayed in order rather than landing between the stash and the submit. That costs the typist the duration of an injection in latency.

## Why it sits where it does

- **`terminal-io/delivery.ts`** — the injection point, and the only place that knows the full paste/submit sequence.
- **`TerminalIOService`** — owns whether a pane holds a draft, because every write DevChain makes to a pane already passes through it. No gateway or registry plumbing was needed. Input from a terminal attached to tmux directly is not observed; no draft is assumed there and delivery behaves as it does today.
- **Provider adapters** — the keys are prompt-specific, so `claude` and `codex` declare them (`C-e C-u` to stash, `C-y` to restore), both verified against the real TUIs. `C-e` precedes `C-u` because `C-u` alone kills only to the line start, leaving the text after the cursor for the message to be appended to. Providers that declare nothing keep the existing path unchanged.

## Testing

- Unit tests in `delivery.spec.ts` covering the sequence, the fallbacks, and two explicit regressions: the submit never sharing a command list with the paste, and the pane being taken out of any tmux mode first. They fail without the corresponding code.
- Validated against real `claude` and `codex` sessions driving the actual service: 9 rounds with the draft restored exactly once and never merged; copy-mode and busy-agent cases included. The copy-mode test reproduces the original corruption when pointed at the unfixed code.
- `pnpm exec jest`: 1620 tests pass across the touched modules; typecheck and lint clean.

## Known limitations

- **A multiline draft is not preserved.** The stash keys clear one line, so it cannot be moved aside; such drafts are detected and left alone, which means the message merges into the draft as it does today. Fixing it needs a way to clear a whole multi-line prompt while retaining the text.
- **The restored cursor sits at the end of the draft**, not where it was — the kill ring carries text, not cursor position.
- Only `claude` and `codex` are covered, since the keys were verified against those two TUIs.

I could not find an existing issue for this (searched open and closed). Happy to split the commit, adjust the provider list, or move the `PromptDraftKeys` type if you would rather the providers module not import from `terminal`.
